### PR TITLE
Mod all cards in stacks, not just first

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ For installation instructions [see this guide](https://github.com/thomasloven/ha
 
 card-modder can be used to apply CSS styling to any lovelace card.
 
+Styles are automatically applied recursively to all cards within stacks.
+
 Any CSS style can be used, and will be applied to the base element of the card
 (`<ha-card>`). Most cards use css variables for styling, and to find out which
 ones, I recommend either the official ["partial list of variables

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For installation instructions [see this guide](https://github.com/thomasloven/ha
 | type | string | **Required** | `custom:card-modder`
 | card | object | **Required** | The card you wish to style
 | style | list | none | List of css styles to apply to card
-| extra_styles | string | none | Extra style data to add to card environment
+| extra\_styles | string | none | Extra style data to add to card environment
 | report\_size | number | none | Size to report
 
 # Styling
@@ -76,6 +76,8 @@ Templates are on the form `[[ domain.entity.state ]]` or `[[ domain.entity.attri
       - light.bed_light
 ```
 ![skarminspelning 2018-12-13 kl 00 05 45 mov](https://user-images.githubusercontent.com/1299821/49904941-3261e680-fe6c-11e8-8d7d-25b6fbbfc9bf.gif)
+
+Note that this doesn't work reliably with stacks at this point.
 
 
 # Extra styles

--- a/card-modder.js
+++ b/card-modder.js
@@ -29,6 +29,7 @@ class CardModder extends cardTools.LitElement {
       config.card.entities = config.entities;
 
     this.card = cardTools.createCard(config.card);
+    this._cards = [this.card];
     if(this._hass)
       this.card.hass = this._hass;
 
@@ -56,16 +57,8 @@ class CardModder extends cardTools.LitElement {
   async _cardMod(root) {
     if(!this._config.style && !this._config.extra_styles) return;
 
-    let recursiveRoots = null
-    if (root._cards) {
-      // Stacks
-      recursiveRoots = root._cards;
-    } else if(root.card && root.card._cards) {
-      // CardModders containing a Stack
-      recursiveRoots = root.card._cards;
-    }
-    if (recursiveRoots && recursiveRoots.length) {
-      recursiveRoots.forEach(c => this._cardMod(c));
+    if (root._cards && root._cards.length) {
+      root._cards.forEach(c => this._cardMod(c));
       return;
     }
 

--- a/card-modder.js
+++ b/card-modder.js
@@ -33,7 +33,7 @@ class CardModder extends cardTools.LitElement {
       this.card.hass = this._hass;
 
     if(this._config)
-      this._cardMod();
+      this._cardMod(this.card);
 
     this._config = config;
 
@@ -50,13 +50,25 @@ class CardModder extends cardTools.LitElement {
   }
 
   async firstUpdated() {
-    this._cardMod();
+    this._cardMod(this.card);
   }
 
-  async _cardMod() {
+  async _cardMod(root) {
     if(!this._config.style && !this._config.extra_styles) return;
 
-    let root = this.card;
+    let recursiveRoots = null
+    if (root._cards) {
+      // Stacks
+      recursiveRoots = root._cards;
+    } else if(root.card && root.card._cards) {
+      // CardModders containing a Stack
+      recursiveRoots = root.card._cards;
+    }
+    if (recursiveRoots && recursiveRoots.length) {
+      recursiveRoots.forEach(c => this._cardMod(c));
+      return;
+    }
+
     let target = null;
     let styles = null;
     while(!target) {
@@ -100,7 +112,7 @@ class CardModder extends cardTools.LitElement {
       root = this;
     }
     if(!target && this.attempts) // Try again
-      setTimeout(() => this._cardMod(), 100);
+      setTimeout(() => this._cardMod(root), 100);
     this.attempts--;
     target = target || this.card;
 


### PR DESCRIPTION
This change iterates through the `_cards` property (the array of cards in a HuiStackCard, the base class for horizontal or vertical stacks), only if it exists, to apply the same mods to each sub-card in a stack.  Previously, the mods only applied to the first card in a stack given the `document.querySelector` calls return the first matching element only.

If the given card doesn't have the `_cards` property, the same original behaviour is applied, eg to just the card itself, so this is fully backwards compatible.