### PR TITLE
Modify card if only extra_styles is specified

### DIFF
--- a/card-modder.js
+++ b/card-modder.js
@@ -54,7 +54,7 @@ class CardModder extends cardTools.LitElement {
   }
 
   async _cardMod() {
-    if(!this._config.style) return;
+    if(!this._config.style && !this._config.extra_styles) return;
 
     let root = this.card;
     let target = null;


### PR DESCRIPTION
Currently, `style` has to be specified on a modded card for the `_cardMod()` function to be execute.  This can be worked around with specifying `style: []` (or similar) in YAML but this small fix in this PR checks if `style` or `extra_styles` as specified, allowing a config like this to work, where you're not styling the card but just specific contents:

```yaml
- type: custom:card-modder
  extra_styles: >
    strong { font-family: 'Comic Sans MS' }
  card:
    type: markdown
    content: '**Hello world**'
```

(this is just an example, I'm not _actually_ using Comic Sans 😛) 